### PR TITLE
Integrate with huggingface

### DIFF
--- a/train/models.py
+++ b/train/models.py
@@ -4,6 +4,7 @@ from preprocessing.nn_dataset import MAX_SEQ
 from preprocessing.nn_dataset import position_encoding_init
 from train.external import VariationalDropout
 from train.transformer import TransformerDecoder, TransformerDecoderLayer, TransformerEncoder, TransformerEncoderLayer
+from huggingface_hub import PyTorchModelHubMixin
 
 """
 File containing classes representing various Neural architectures
@@ -11,7 +12,13 @@ File containing classes representing various Neural architectures
 
 
 # MARK:- TonicNet
-class TonicNet(nn.Module):
+class TonicNet(
+    nn.Module,
+    PyTorchModelHubMixin,
+    library_name="tonicnet",
+    repo_url="https://github.com/omarperacha/TonicNet",
+    tags=["polyphonic-music"],
+):
     def __init__(self, nb_tags, nb_layers=1, z_dim =0,
                  nb_rnn_units=100, batch_size=1, seq_len=1, dropout=0.0):
         super(TonicNet, self).__init__()


### PR DESCRIPTION
this pr will integrate your model with huggingface using PyTorchModelHubMixin.
by inheriting from `PyTorchModelHubMixin` you can access 3 main methods similar to the transformers library which are : 
* `from_pretrained`
* `save_pretrained`
* `push_to_hub`

Additionally, sharing your model on huggingface will add more visibility and ease of access to your model, you can also keep track of how many people have downloaded your model each month.

If you have some checkpoints you want to put on huggingface, I added a step-by-step colab notebook explaining how you can do it in [here](https://colab.research.google.com/drive/1SlPbHkG3caiar2FdfnLETmtOTwHiPMao?usp=sharing)


Finally, I wanted to express my astonishment at achieving state-of-the-art performance, awesome work! 

Regards
Hafedh Hichri
Oss Contributor 
